### PR TITLE
Fix: follow check값 모듈화 조정

### DIFF
--- a/controllers/followController.js
+++ b/controllers/followController.js
@@ -10,7 +10,7 @@ const keyError = REQUIRE_KEYS => {
 
 // 상세피드에서 로그인유저의 팔로잉 체크여부
 const followCheck = async (req, res) => {
-  const { id } = req.params;
+  const { id } = req.body;
   const user_id = req.user_id;
   const result = await followService.followCheck(id, user_id);
   res.status(200).json(result);

--- a/models/channelDao.js
+++ b/models/channelDao.js
@@ -1,10 +1,10 @@
 const myDataSource = require('.');
 
 const channel = async (following_id, user_id) => {
-  let userInfo = await myDataSource.query(
+  let writerInfo = await myDataSource.query(
     `
     SELECT 
-      id AS user_id, 
+      id, 
       nickname, 
       kor_name, 
       eng_name, 
@@ -116,7 +116,7 @@ const channel = async (following_id, user_id) => {
     [following_id]
   );
   return {
-    userInfo,
+    writerInfo,
     userFollowingInfo,
     userFollowerInfo,
     usersPosts,

--- a/models/followDao.js
+++ b/models/followDao.js
@@ -6,17 +6,15 @@ const followCheck = async (id, user_id) => {
     .query(
       `
       SELECT
-        EXISTS (
-          SELECT
-            f.id
-          FROM
-            Follow f
-          LEFT JOIN Works_Posting wp ON
-            wp.user_id = f.following_id
-          WHERE
-            wp.id = ?
-            AND follower_id = ?
-        ) AS success
+          EXISTS(
+                  SELECT
+                      id
+                  FROM
+                      Follow f
+                  WHERE
+                      following_id = ?
+                    AND follower_id = ?
+              ) AS success
     `,
       [id, user_id]
     )

--- a/routes/followRouter.js
+++ b/routes/followRouter.js
@@ -5,8 +5,9 @@ const { asyncWrap } = require('../utils/util');
 const { validateToken } = require('../middlewares/validateToken');
 const followController = require('../controllers/followController');
 
-router.get(
-  '/:id',
+// getFollow (팔로우 여부 확인)
+router.post(
+  '/check',
   asyncWrap(validateToken),
   asyncWrap(followController.followCheck)
 );


### PR DESCRIPTION
## :: follow check 로직 변경

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 상세페이지에서도, channel에서도 동일한 요청으로 가져올 수 있도록 route주소 및 로직 미세 수정
- channel에서의 피드작성자 ID값의 객체명 userInfo => writerInfo, key값 id =>  writer_id로 변경
- followCheck controller단에서 requireKey 에러 핸들링 추가
- followCheck route HTTP method 수정 : get => post (기존 params에서 받아오던 ID를 body로 처리)



<br />

