### PR TITLE
Feature/delete feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ $RECYCLE.BIN/
 
 config/
 *.rtf
+formemo.js

--- a/controllers/workController.js
+++ b/controllers/workController.js
@@ -1,4 +1,5 @@
 const workService = require('../services/workService');
+const userService = require('../services/userService');
 
 // 카테고리별 총 게시물 수 + 최신 feed list
 const worksList = async (req, res) => {
@@ -14,7 +15,32 @@ const feed = async (req, res) => {
   res.status(200).json(result);
 };
 
+const deletefeed = async (req, res) => {
+  user_id = req.user_id;
+  const { id } = req.params;
+  // const { posting_id } = req.body;
+  const posting_id = id;
+  const REQUIRE_KEYS = [user_id, posting_id];
+
+  Object.keys(REQUIRE_KEYS).map(key => {
+    if (!REQUIRE_KEYS[key]) {
+      throw new Error(`KEY_ERROR: ${key}`);
+    }
+  });
+
+  const userInfoById = await userService.getAccountInfo(user_id);
+
+  if (user_id !== userInfoById.id) {
+    throw new Error(`ONLY WRITER CAN DELETE THE FEED`);
+  }
+
+  await workService.deletefeed(posting_id);
+
+  res.status(204).json({ data: null });
+};
+
 module.exports = {
   worksList,
   feed,
+  deletefeed,
 };

--- a/controllers/workController.js
+++ b/controllers/workController.js
@@ -17,9 +17,7 @@ const getFeed = async (req, res) => {
 
 const deletefeed = async (req, res) => {
   user_id = req.user_id;
-  const { id } = req.params;
-  // const { posting_id } = req.body;
-  const posting_id = id;
+  const posting_id = req.params.id;
   const REQUIRE_KEYS = [user_id, posting_id];
 
   Object.keys(REQUIRE_KEYS).map(key => {
@@ -36,7 +34,7 @@ const deletefeed = async (req, res) => {
 
   await workService.deletefeed(posting_id);
 
-  res.status(204).json({ data: null });
+  res.status(204).json({ message: 'FEED DELETED' });
 };
 
 module.exports = {

--- a/models/workDao.js
+++ b/models/workDao.js
@@ -539,16 +539,28 @@ const deletefeed = async posting_id => {
       `DELETE FROM Works_Tag_names WHERE id = ${tagsShouldBeDeletedFromDB[i][0].tag_id}`
     );
   }
-  await myDataSource.query(`DELETE FROM Comments WHERE posting_id = (?)`, [
+  await myDataSource.query(`DELETE FROM Comment WHERE posting_id = (?)`, [
     posting_id,
   ]);
   await myDataSource.query(
     `DELETE FROM Works_Sympathy_Count WHERE posting_id = (?)`,
     [posting_id]
   );
-  await myDataSource.query(`DELETE FROM Works_posting WHERE posting_id = (?)`, [
+  await myDataSource.query(
+    `
+    SET foreign_key_checks = 0
+    `
+  );
+
+  await myDataSource.query(`DELETE FROM Works_posting WHERE id = (?)`, [
     posting_id,
   ]);
+
+  await myDataSource.query(
+    `
+    SET foreign_key_checks = 1
+    `
+  );
 };
 
 module.exports = {

--- a/models/workDao.js
+++ b/models/workDao.js
@@ -546,21 +546,13 @@ const deletefeed = async posting_id => {
     `DELETE FROM Works_Sympathy_Count WHERE posting_id = (?)`,
     [posting_id]
   );
-  await myDataSource.query(
-    `
-    SET foreign_key_checks = 0
-    `
-  );
+  await myDataSource.query(`SET foreign_key_checks = 0;`);
 
   await myDataSource.query(`DELETE FROM Works_posting WHERE id = (?)`, [
     posting_id,
   ]);
 
-  await myDataSource.query(
-    `
-    SET foreign_key_checks = 1
-    `
-  );
+  await myDataSource.query(`SET foreign_key_checks = 1;`);
 };
 
 module.exports = {

--- a/routes/workRouter.js
+++ b/routes/workRouter.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-
+const { validateToken } = require('../middlewares/validateToken');
 const { asyncWrap } = require('../utils/util');
 const workController = require('../controllers/workController');
 
@@ -8,5 +8,6 @@ const workController = require('../controllers/workController');
 router.get('', asyncWrap(workController.worksList));
 router.get('/feed/:id', asyncWrap(workController.feed));
 router.get('/:sort', asyncWrap(workController.worksList)); // sort 종류 ('recommendpoint', 'sympathycnt')
+router.delete('/feed/:id', validateToken, workController.deletefeed);
 
 module.exports = router;

--- a/services/workService.js
+++ b/services/workService.js
@@ -15,7 +15,12 @@ const feed = async id => {
   return await workDao.feed(id);
 };
 
+const deletefeed = async posting_id => {
+  await workDao.deletefeed(posting_id);
+};
+
 module.exports = {
   worksList,
   feed,
+  deletefeed,
 };

--- a/services/workService.js
+++ b/services/workService.js
@@ -29,6 +29,10 @@ const getFeed = async id => {
   return await workDao.getFeed(id);
 };
 
+const deletefeed = async posting_id => {
+  await workDao.deletefeed(posting_id);
+};
+
 module.exports = {
   getWorkList,
   getFeed,

--- a/utils/util.js
+++ b/utils/util.js
@@ -98,4 +98,10 @@ function errorHandler(err, _1, res, _2) {
     .json({ message: responseInfo.message || '' });
 }
 
-module.exports = { morganCustomFormat, asyncWrap, errorHandler, util, upload };
+module.exports = {
+  morganCustomFormat,
+  asyncWrap,
+  errorHandler,
+  util,
+  upload,
+};


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

게시물이 삭제 될 때,
관련 태그, 좋아요, 댓글이 함께 삭제될 수 있도록 구현합니다.

## :: 구현 사항 설명 

하기 2가지를 중점적으로 구현하였습니다.

1. 게시글 삭제시, 외래키 충돌을 예방하기 위한 관련 자료삭제 순서 조정
->  태그, 좋아요, 댓글, 게시글 순서로 삭제됩니다.

2. 게시글 삭제 시, 사용처가 없어지는 태그를 삭제하기 위한 태그데이터 확인
-> 자바스크립트 구문을 이용하여 해당 태그를 확인 및 삭제합니다.

## :: 성장 포인트
- 자료 삭제 순서에 따른 외래키 충돌에 관해 머릿속으로 그려보는 능력을 기를 수 있었습니다.
- 아직 많이 모자라지만 머릿속에 있는 로직을 자바스크립트를 통해 구현해보았습니다.

<br />

## :: 기타 질문 및 특이 사항

하기 2가지를 개선 할 필요가 있습니다.
1. 게시글 삭제시 게시글의 이미지 동시 삭제
-> AWS S3권한 문제를 해결하지 못해 이번에는 이뤄지지 못했습니다.

2. 쿼리문을 활용한 로직의 간소화
-> 아직 쿼리문에 익숙하지 않아 자바스크립트를 사용하여 불필요하게 코드가 길어졌습니다.
해당 부분을 개선할 수 있도록 해야겠습니다. 