### PR TITLE
Fix/sympathy and search

### DIFF
--- a/controllers/searchListController.js
+++ b/controllers/searchListController.js
@@ -3,8 +3,8 @@ const searchListService = require('../services/searchListService');
 // 검색어 입력시 + 카테고리 설정
 const getSearchList = async (req, res) => {
   const { query } = req.query;
-  const { category_id } = req.query;
-  const result = await searchListService.getSearchList(query, category_id);
+  const { category_name } = req.query;
+  const result = await searchListService.getSearchList(query, category_name);
   res.status(200).json(result);
 };
 

--- a/controllers/sympathyController.js
+++ b/controllers/sympathyController.js
@@ -8,6 +8,18 @@ const catchKeyError = REQUIRE_KEYS => {
   });
 };
 
+// feed상세에서 로그인유저의 공감여부 확인
+const findSympathyOfFeedByUser = async (req, res) => {
+  let user_id = req.user_id;
+  const posting_id = req.params.id;
+
+  const result = await sympathyService.findSympathyOfFeedByUser(
+    posting_id,
+    user_id
+  );
+  res.status(200).json(result);
+};
+
 // 공감
 const createSympathy = async (req, res) => {
   const { posting_id, sympathy_id } = req.body;
@@ -37,6 +49,7 @@ const deleteSympathy = async (req, res) => {
 };
 
 module.exports = {
+  findSympathyOfFeedByUser,
   createSympathy,
   deleteSympathy,
 };

--- a/models/searchListDao.js
+++ b/models/searchListDao.js
@@ -71,9 +71,9 @@ const findQuerySearchResult = `
   `;
 
 // 검색어 입력시 + 카테고리 설정
-const getSearchList = async (query, category_id) => {
+const getSearchList = async (query, category_name) => {
   // TODO 서비스단으로 올리기!!
-  if (!category_id) {
+  if (!category_name) {
     const resultCount = await myDataSource.query(
       `
         SELECT 
@@ -105,18 +105,20 @@ const getSearchList = async (query, category_id) => {
     // TODO AND가 제대로 안먹히는듯, 손봐야 함
     const resultCount = await myDataSource.query(
       `
-        SELECT 
-          COUNT(*) result_cnt
-        FROM 
-          Works_Posting wp  
-        WHERE 
-          wp.title LIKE CONCAT('%', ?, '%')
-          OR wp.content LIKE CONCAT('%', ?, '%')
-          AND wp.category_id = CONCAT('%', ?, '%')
-        ORDER BY 
-          wp.created_at DESC 
+          SELECT
+              COUNT(*) result_cnt
+          FROM
+              Works_Posting wp
+                  LEFT JOIN Works_Category wc
+                            ON wp.category_id = wc.id
+          WHERE
+              (wp.title LIKE CONCAT('%', ?, '%')
+                  OR wp.content LIKE CONCAT('%', ?, '%'))
+            AND wc.eng_category_name = ?
+          ORDER BY
+              wp.created_at DESC 
         `,
-      [query, query, category_id]
+      [query, query, category_name]
     );
 
     const searchResult = await myDataSource.query(
@@ -127,7 +129,7 @@ const getSearchList = async (query, category_id) => {
         ORDER BY 
           wp.created_at DESC 
       `,
-      [query, query, category_id]
+      [query, query, category_name]
     );
     return { resultCount, searchResult };
   }

--- a/models/searchListDao.js
+++ b/models/searchListDao.js
@@ -1,73 +1,80 @@
 const myDataSource = require('.');
 
 const findQuerySearchResult = `
-  WITH tables1 AS (
-    SELECT
-      wp.id AS id,
-      COUNT(*) AS comment_cnt
-    FROM
-      Works_Posting wp
-    JOIN Comment c ON
-      wp.id = c.posting_id
-    GROUP BY
-      wp.id 
-  ),
-  
-  tables2 AS (
-    SELECT
-      wp.id AS id,
-      COUNT(*) AS sympathy_cnt
-    FROM
-      Works_Posting wp
-    JOIN Works_Sympathy_Count wsc ON
-      wp.id = wsc.posting_id
-    LEFT JOIN Works_Sympathy ws ON
-      wsc.sympathy_id = ws.id
-    GROUP BY
-      wp.id 
-  ),
-  tables3 AS (
-    SELECT
-      id,
-      posting_id,
-      upload_url AS img_url
-    FROM
-      upload_file
-    WHERE
-      (posting_id,
-      id) 
-      IN (
+    WITH tables1 AS (
         SELECT
-          posting_id,
-          MAX(id)
+            wp.id AS id,
+            COUNT(*) AS comment_cnt
         FROM
-          upload_file
-        WHERE
-          file_sort_id = 1
+            Works_Posting wp
+                JOIN Comment c ON
+                wp.id = c.posting_id
         GROUP BY
-          posting_id ) 
-              ) 
-            
-  SELECT
-    wp.id,
-    u.kor_name AS nickname,
-    u.profile_image,
-    c.img_url,
-    wp.title,
-    IFNULL(a.comment_cnt, '0') comment_cnt,
-    IFNULL(b.sympathy_cnt, '0') sympathy_cnt,
-    wp.view_count,
-    SUBSTRING(wp.created_at, 1, 10) AS created_at
-  FROM
-    Works_Posting wp
-  LEFT JOIN Users u ON
-    wp.user_id = u.id
-  LEFT JOIN tables3 c ON
-    c.posting_id = wp.id
-  LEFT JOIN tables1 a ON
-    a.id = wp.id
-  LEFT JOIN tables2 b ON
-    b.id = wp.id
+            wp.id
+    ),
+
+         tables2 AS (
+             SELECT
+                 wp.id AS id,
+                 COUNT(*) AS sympathy_cnt
+             FROM
+                 Works_Posting wp
+                     JOIN Works_Sympathy_Count wsc ON
+                     wp.id = wsc.posting_id
+                     LEFT JOIN Works_Sympathy ws ON
+                     wsc.sympathy_id = ws.id
+             GROUP BY
+                 wp.id
+         ),
+         tables3 AS (
+             SELECT
+                 id,
+                 posting_id,
+                 upload_url AS img_url
+             FROM
+                 upload_file
+             WHERE
+                     (posting_id,
+                      id)
+                     IN (
+                         SELECT
+                             posting_id,
+                             MAX(id)
+                         FROM
+                             upload_file
+                         WHERE
+                             file_sort_id = 1
+                         GROUP BY
+                             posting_id )
+         )
+
+    SELECT
+        wp.id,
+        u.kor_name AS nickname,
+        u.profile_image,
+        c.img_url,
+        wp.title,
+        wc.eng_category_name AS category_name,
+        IFNULL(a.comment_cnt, '0') comment_cnt,
+        IFNULL(b.sympathy_cnt, '0') sympathy_cnt,
+        wp.view_count,
+        SUBSTRING(wp.created_at, 1, 10) AS created_at
+    FROM
+        Works_Posting wp
+            LEFT JOIN Users u ON
+            wp.user_id = u.id
+            LEFT JOIN tables3 c ON
+            c.posting_id = wp.id
+            LEFT JOIN tables1 a ON
+            a.id = wp.id
+            LEFT JOIN tables2 b ON
+            b.id = wp.id
+            LEFT JOIN Works_Category wc ON
+            wp.category_id = wc.id
+            LEFT JOIN Works_Posting_tags wpt ON
+            wp.id = wpt.posting_id
+            LEFT JOIN Works_tag_names wtn ON
+            wpt.tag_id = wtn.id
   `;
 
 // 검색어 입력시 + 카테고리 설정
@@ -76,17 +83,20 @@ const getSearchList = async (query, category_name) => {
   if (!category_name) {
     const resultCount = await myDataSource.query(
       `
-        SELECT 
+      SELECT
           COUNT(*) result_cnt
-        FROM 
-          Works_Posting wp  
-        WHERE 
-          wp.title  LIKE CONCAT('%', ?, '%') 
-           OR wp.content LIKE CONCAT('%', ?, '%') 
-        ORDER BY 
-          wp.created_at DESC 
+      FROM
+          Works_Posting wp
+              LEFT JOIN Works_Posting_tags wpt
+                        ON wp.id = wpt.posting_id
+              LEFT JOIN Works_tag_names wtn
+                        ON wpt.tag_id = wtn.id
+      WHERE
+          wp.title LIKE CONCAT('%', ?, '%')
+        OR wp.content LIKE CONCAT('%', ?, '%')
+        OR wtn.name LIKE CONCAT('%', ?, '%') 
         `,
-      [query, query]
+      [query, query, query]
     );
 
     const searchResult = await myDataSource.query(
@@ -95,10 +105,11 @@ const getSearchList = async (query, category_name) => {
         WHERE 
           wp.title LIKE CONCAT('%', ?, '%') 
             OR wp.content LIKE CONCAT('%', ?, '%')
+            OR wtn.name LIKE CONCAT('%', ?, '%')
         ORDER BY 
           wp.created_at DESC 
         `,
-      [query, query]
+      [query, query, query]
     );
     return { resultCount, searchResult };
   } else {
@@ -111,25 +122,33 @@ const getSearchList = async (query, category_name) => {
               Works_Posting wp
                   LEFT JOIN Works_Category wc
                             ON wp.category_id = wc.id
+                  LEFT JOIN Works_Posting_tags wpt
+                            ON wp.id = wpt.posting_id
+                  LEFT JOIN Works_tag_names wtn
+                            ON wpt.tag_id = wtn.id
           WHERE
               (wp.title LIKE CONCAT('%', ?, '%')
-                  OR wp.content LIKE CONCAT('%', ?, '%'))
+                  OR wp.content LIKE CONCAT('%', ?, '%')
+                  OR wtn.name LIKE CONCAT('%', ?, '%'))
             AND wc.eng_category_name = ?
           ORDER BY
-              wp.created_at DESC 
+              wp.created_at DESC
         `,
-      [query, query, category_name]
+      [query, query, query, category_name]
     );
 
     const searchResult = await myDataSource.query(
       `
         ${findQuerySearchResult}
         WHERE 
-          wp.title LIKE CONCAT('%', ?, '%') OR wp.content LIKE CONCAT('%', ?, '%') AND wp.category_id = CONCAT('%', ?, '%')
+          (wp.title LIKE CONCAT('%', ?, '%') 
+              OR wp.content LIKE CONCAT('%', ?, '%')
+              OR wtn.name LIKE CONCAT('%', ?, '%'))
+             AND wc.eng_category_name = ?
         ORDER BY 
           wp.created_at DESC 
       `,
-      [query, query, category_name]
+      [query, query, query, category_name]
     );
     return { resultCount, searchResult };
   }

--- a/models/sympathyDao.js
+++ b/models/sympathyDao.js
@@ -2,19 +2,26 @@ const myDataSource = require('.');
 
 // 피드에서 로그인유저의 공감여부 확인하기
 const findSympathyOfFeedByUser = async (posting_id, user_id) => {
-  const checkSympathy = await myDataSource.query(
-    `
+  return await myDataSource
+    .query(
+      `
       SELECT
-        COUNT(*) check_cnt
+        COUNT(*) checkSympathyByUser
       FROM
         Works_Sympathy_Count wsc
       WHERE
         posting_id = ?
         AND user_id = ?
     `,
-    [posting_id, user_id]
-  );
-  return checkSympathy[0].check_cnt;
+      [posting_id, user_id]
+    )
+    .then(value => {
+      const [item] = value;
+      console.log('dao result =', item.checkSympathyByUser);
+      return {
+        checkSympathyByUser: item.checkSympathyByUser === '1',
+      };
+    });
 };
 
 // 공감하기
@@ -31,28 +38,6 @@ const createSympathy = async (posting_id, user_id, sympathy_id) => {
     `,
     [user_id, posting_id, sympathy_id]
   );
-
-  const checkSympathyByUser = await myDataSource
-    .query(
-      `
-    SELECT exists(
-               SELECT
-                   *
-               FROM
-                   Works_Sympathy_Count wsc
-               WHERE
-                       user_id = ?
-                 AND posting_id = ?
-           ) AS checkSympathyByUser
-     `,
-      [user_id, posting_id]
-    )
-    .then(value => {
-      const [item] = value;
-      return {
-        checkSympathyByUser: item.checkSympathyByUser == 1,
-      };
-    });
 
   const getSympathyByUser = await myDataSource.query(
     `
@@ -97,7 +82,7 @@ const createSympathy = async (posting_id, user_id, sympathy_id) => {
     `,
     [posting_id]
   );
-  return { checkSympathyByUser, getSympathyByUser, getSympathiesCount };
+  return { getSympathyByUser, getSympathiesCount };
 };
 
 // 공감 수정하기
@@ -114,28 +99,6 @@ const updateSympathy = async (posting_id, user_id, sympathy_id) => {
       `,
     [sympathy_id, user_id, posting_id]
   );
-
-  const checkSympathyByUser = await myDataSource
-    .query(
-      `
-    SELECT exists(
-               SELECT
-                   *
-               FROM
-                   Works_Sympathy_Count wsc
-               WHERE
-                       user_id = ?
-                 AND posting_id = ?
-           ) AS checkSympathyByUser
-     `,
-      [user_id, posting_id]
-    )
-    .then(value => {
-      const [item] = value;
-      return {
-        checkSympathyByUser: item.checkSympathyByUser == 1,
-      };
-    });
 
   const getSympathyByUser = await myDataSource.query(
     `
@@ -181,7 +144,7 @@ const updateSympathy = async (posting_id, user_id, sympathy_id) => {
       `,
     [posting_id]
   );
-  return { checkSympathyByUser, getSympathyByUser, getSympathiesCount };
+  return { getSympathyByUser, getSympathiesCount };
 };
 
 // 공감 취소
@@ -197,28 +160,6 @@ const deleteSympathy = async (posting_id, user_id) => {
     `,
     [user_id, posting_id]
   );
-
-  const checkSympathyByUser = await myDataSource
-    .query(
-      `
-    SELECT exists(
-               SELECT
-                   *
-               FROM
-                   Works_Sympathy_Count wsc
-               WHERE
-                       user_id = ?
-                 AND posting_id = ?
-           ) AS checkSympathyByUser
-     `,
-      [user_id, posting_id]
-    )
-    .then(value => {
-      const [item] = value;
-      return {
-        checkSympathyByUser: item.checkSympathyByUser == 1,
-      };
-    });
 
   const getSympathiesCount = await myDataSource.query(
     `
@@ -252,7 +193,7 @@ const deleteSympathy = async (posting_id, user_id) => {
     [posting_id]
   );
 
-  return { checkSympathyByUser, getSympathiesCount };
+  return { getSympathiesCount };
 };
 
 module.exports = {

--- a/routes/sympathyRouter.js
+++ b/routes/sympathyRouter.js
@@ -5,6 +5,11 @@ const { asyncWrap } = require('../utils/util');
 const { validateToken } = require('../middlewares/validateToken');
 const sympathyController = require('../controllers/sympathyController');
 
+router.get(
+  '/:id',
+  asyncWrap(validateToken),
+  asyncWrap(sympathyController.findSympathyOfFeedByUser)
+);
 router.post(
   '',
   asyncWrap(validateToken),

--- a/services/searchListService.js
+++ b/services/searchListService.js
@@ -1,8 +1,8 @@
 const searchListDao = require('../models/searchListDao');
 
 // 검색어 입력시 + 카테고리 설정
-const getSearchList = async (query, category_id) => {
-  return await searchListDao.getSearchList(query, category_id);
+const getSearchList = async (query, category_name) => {
+  return await searchListDao.getSearchList(query, category_name);
 };
 
 module.exports = { getSearchList };

--- a/services/searchListService.js
+++ b/services/searchListService.js
@@ -2,7 +2,10 @@ const searchListDao = require('../models/searchListDao');
 
 // 검색어 입력시 + 카테고리 설정
 const getSearchList = async (query, category_name) => {
-  return await searchListDao.getSearchList(query, category_name);
+  const changeDao = category_name
+    ? searchListDao.getSearchListWithCategory(query, category_name)
+    : searchListDao.getSearchList(query);
+  return await changeDao;
 };
 
 module.exports = { getSearchList };

--- a/services/sympathyService.js
+++ b/services/sympathyService.js
@@ -11,7 +11,7 @@ const createSympathy = async (posting_id, user_id, sympathy_id) => {
     posting_id,
     user_id
   );
-  if (findSympathyOfFeedByUser === '0') {
+  if (findSympathyOfFeedByUser.checkSympathyByUser === false) {
     return await sympathyDao.createSympathy(posting_id, user_id, sympathy_id);
   } else {
     return await sympathyDao.updateSympathy(posting_id, user_id, sympathy_id);

--- a/services/sympathyService.js
+++ b/services/sympathyService.js
@@ -1,5 +1,10 @@
 const sympathyDao = require('../models/sympathyDao');
 
+// 피드 상세에서 로그인유저의 공감여부 확인
+const findSympathyOfFeedByUser = async (posting_id, user_id) => {
+  return await sympathyDao.findSympathyOfFeedByUser(posting_id, user_id);
+};
+
 // 공감
 const createSympathy = async (posting_id, user_id, sympathy_id) => {
   const findSympathyOfFeedByUser = await sympathyDao.findSympathyOfFeedByUser(
@@ -19,6 +24,7 @@ const deleteSympathy = async (posting_id, user_id) => {
 };
 
 module.exports = {
+  findSympathyOfFeedByUser,
   createSympathy,
   deleteSympathy,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표

- query검색 외 category검색 유무에 따른 service단에서의 전달 처리
- 로그인유저의 피드게시물에 대한 공감여부의 체크값 도입
- 로그인유저의 피드게시물에 대한 공감여부의 체크값을 boolean값으로 반환
- 로그인유저의 피드게시물에 대한 공감여부의 체크값 API 분리
- 검색창에서의 tag검색기능 보류

<br />

여기까지를 renewal Photofolio version2.0으로 마무리하고 Main 브랜치로 올릴까 합니다. 
main브랜치로의 merge 이후, 각자 개인 레포로 fork해가시면 될것 같습니다. 